### PR TITLE
ci(workflow): Build and push container image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ on:
       - Containerfile
       - .containerignore
       - 'data/**'
-      - .github/workflows/podman-publish.yml
+      - .github/workflows/docker-publish.yml
     branches:
       - main
       - develop
@@ -77,6 +77,8 @@ jobs:
       - name: Extract container metadata
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           # `images` property is converted to lowercase
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/podman-publish.yml
+++ b/.github/workflows/podman-publish.yml
@@ -57,82 +57,52 @@ jobs:
         with:
           cosign-release: 'v2.2.4'
 
-      - name: Convert container envs to lowercases
-        id: lower
-        run: |
-          echo "IMAGE_NAME=${REGISTRY}/${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
-          owner="${{ github.repository_owner }}"
-          echo "LOGIN_REGISTRY=${REGISTRY}/${owner,,}" >> "$GITHUB_OUTPUT"
-
-      # Login to a container image registry
-      # https://github.com/redhat-actions/podman-login
-      - name: Log in to a ${{ env.REGISTRY }}
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+      # Login against a Docker registry
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ github.actor }}
           password: ${{ github.token }}
-          registry: ${{ steps.lower.outputs.LOGIN_REGISTRY }}
+          registry: ${{ env.REGISTRY }}
 
-      # Extract metadata (tags, labels) for Buildah
+      # Extract metadata (tags, labels) for Container
       # https://github.com/docker/metadata-action
-      - name: Extract buildah metadata
+      - name: Extract container metadata
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           # `images` property is converted to lowercase
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=edge,branch=develop
             type=ref,event=pr
-          # `tags` in `redhat-actions/buildah-build` is SSV format
-          sep-tags: ' '
           labels: |
             org.opencontainers.image.title=My ComfyUI Container
             org.opencontainers.image.description=REST API server with ComfyUI backend
 
-      # Build container image with Buildah
-      # https://github.com/redhat-actions/buildah-build
-      - name: Build container image
-        id: build-image
-        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
         with:
-          # `image` property is converted to lowercase
-          # https://github.com/redhat-actions/buildah-build/blob/7a95fa7ee0f02d552a32753e7414641a04307056/src/index.ts#L48
-          image: ${{ env.IMAGE_NAME }}
-          # full name (include registry and image name)
+          context: .
+          file: Containerfile
+          push: ${{ github.base_ref != 'main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          context: .
-          containerfiles: |
-            ./Containerfile
-          build-args: |
-            TARGETARCH=${{ matrix.arch }}
-          layers: true
-          extra-args: |
-            --cache-to=${{ env.IMAGE_NAME }}
-            --cache-from=${{ env.IMAGE_NAME }}
-
-      - name: Check image metadata
-        run: |
-          set -x
-          buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq ".OCIv1.architecture"
-          buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq ".Docker.architecture"
-
-      # Push container image to registry with Podman
-      # If PR to main branch, skip.
-      # https://github.com/redhat-actions/push-to-registry
-      - name: Push image to ${{ env.REGISTRY }} registry
-        if: ${{ github.base_ref != 'main' }}
-        id: push
-        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
-        with:
-          #image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          #registry: ${{ env.REGISTRY }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker
@@ -144,8 +114,8 @@ jobs:
         if: ${{ github.base_ref != 'main' }}
         env:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
-          TAGS: ${{ steps.push.outputs.registry-paths }}
-          DIGEST: ${{ steps.push.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: |

--- a/.github/workflows/podman-publish.yml
+++ b/.github/workflows/podman-publish.yml
@@ -119,6 +119,6 @@ jobs:
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: |
-          echo "${TAGS}" | jq -r '.[]' | while read -r image; do
+          echo "${TAGS}" | while read -r image; do
             cosign sign --yes "${image}@${DIGEST}"
           done

--- a/.github/workflows/podman-publish.yml
+++ b/.github/workflows/podman-publish.yml
@@ -89,6 +89,9 @@ jobs:
           labels: |
             org.opencontainers.image.title=My ComfyUI Container
             org.opencontainers.image.description=REST API server with ComfyUI backend
+            maintainer=${{ github.repository_owner }}
+          annotations: |
+            org.opencontainers.image.description=REST API server with ComfyUI backend with multi architecture
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -101,9 +104,14 @@ jobs:
           push: ${{ github.base_ref != 'main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           platforms: linux/${{ matrix.arch }}
           cache-from: type=gha,scope=linux_${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=linux_${{ matrix.arch }}
+          # Disable to avoid 'unknown/unknown' on ghcr.io
+          provenance: false
+          # Disable to avoid 'unknown/unknown' on ghcr.io
+          sbom: false
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/.github/workflows/podman-publish.yml
+++ b/.github/workflows/podman-publish.yml
@@ -108,10 +108,6 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           cache-from: type=gha,scope=linux_${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=linux_${{ matrix.arch }}
-          # Disable to avoid 'unknown/unknown' on ghcr.io
-          provenance: false
-          # Disable to avoid 'unknown/unknown' on ghcr.io
-          sbom: false
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/.github/workflows/podman-publish.yml
+++ b/.github/workflows/podman-publish.yml
@@ -33,9 +33,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            arch: x86_64
+            arch: amd64
           - os: ubuntu-24.04-arm
-            arch: aarch64
+            arch: arm64
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -101,8 +101,9 @@ jobs:
           push: ${{ github.base_ref != 'main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: linux/${{ matrix.arch }}
+          cache-from: type=gha,scope=linux_${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=linux_${{ matrix.arch }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/.github/workflows/podman-publish.yml
+++ b/.github/workflows/podman-publish.yml
@@ -1,0 +1,154 @@
+name: Publish Container Image
+
+on:
+  push:
+    branches:
+      - develop
+    # Publish semver tags as releases.
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    # filter
+    paths:
+      - Containerfile
+      - .containerignore
+      - 'data/**'
+      - .github/workflows/podman-publish.yml
+    branches:
+      - main
+      - develop
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # PR先が main ブランチの場合はレジストリにプッシュしない
+  build-multiarch:
+    name: Build and Push multi-architecture image
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # If PR to main branch, skip.
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: ${{ github.base_ref != 'main' }}
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      - name: Convert container envs to lowercases
+        id: lower
+        run: |
+          echo "IMAGE_NAME=${REGISTRY}/${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
+          owner="${{ github.repository_owner }}"
+          echo "LOGIN_REGISTRY=${REGISTRY}/${owner,,}" >> "$GITHUB_OUTPUT"
+
+      # Login to a container image registry
+      # https://github.com/redhat-actions/podman-login
+      - name: Log in to a ${{ env.REGISTRY }}
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          registry: ${{ steps.lower.outputs.LOGIN_REGISTRY }}
+
+      # Extract metadata (tags, labels) for Buildah
+      # https://github.com/docker/metadata-action
+      - name: Extract buildah metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          # `images` property is converted to lowercase
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=edge,branch=develop
+            type=ref,event=pr
+          # `tags` in `redhat-actions/buildah-build` is SSV format
+          sep-tags: ' '
+          labels: |
+            org.opencontainers.image.title=My ComfyUI Container
+            org.opencontainers.image.description=REST API server with ComfyUI backend
+
+      # Build container image with Buildah
+      # https://github.com/redhat-actions/buildah-build
+      - name: Build container image
+        id: build-image
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+        with:
+          # `image` property is converted to lowercase
+          # https://github.com/redhat-actions/buildah-build/blob/7a95fa7ee0f02d552a32753e7414641a04307056/src/index.ts#L48
+          image: ${{ env.IMAGE_NAME }}
+          # full name (include registry and image name)
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          context: .
+          containerfiles: |
+            ./Containerfile
+          build-args: |
+            TARGETARCH=${{ matrix.arch }}
+          layers: true
+          extra-args: |
+            --cache-to=${{ env.IMAGE_NAME }}
+            --cache-from=${{ env.IMAGE_NAME }}
+
+      - name: Check image metadata
+        run: |
+          set -x
+          buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq ".OCIv1.architecture"
+          buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq ".Docker.architecture"
+
+      # Push container image to registry with Podman
+      # If PR to main branch, skip.
+      # https://github.com/redhat-actions/push-to-registry
+      - name: Push image to ${{ env.REGISTRY }} registry
+        if: ${{ github.base_ref != 'main' }}
+        id: push
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+        with:
+          #image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          #registry: ${{ env.REGISTRY }}
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # If PR to main branch, skip.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.base_ref != 'main' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.push.outputs.registry-paths }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: |
+          echo "${TAGS}" | jq -r '.[]' | while read -r image; do
+            cosign sign --yes "${image}@${DIGEST}"
+          done

--- a/Containerfile
+++ b/Containerfile
@@ -26,13 +26,13 @@ ARG DOWNLOAD_DIR=/tmp/s6
 ARG DOWNLOAD_URL="https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}"
 
 WORKDIR ${S6_ROOTFS}
-RUN --mount=type=tmpfs,dst=/tmp/s6,tmpfs-size=64M \
-  <<EOS sh
+RUN <<EOS sh
   wget -P ${DOWNLOAD_DIR} \
     ${DOWNLOAD_URL}/s6-overlay-noarch.tar.xz \
     ${DOWNLOAD_URL}/s6-overlay-${TARGETARCH}.tar.xz
   tar -C ./ -xJf ${DOWNLOAD_DIR}/s6-overlay-noarch.tar.xz
   tar -C ./ -xJf ${DOWNLOAD_DIR}/s6-overlay-${TARGETARCH}.tar.xz
+  rm -rf ${DOWNLOAD_DIR}
 EOS
 
 # ------------------------------

--- a/Containerfile
+++ b/Containerfile
@@ -27,11 +27,26 @@ ARG DOWNLOAD_URL="https://github.com/just-containers/s6-overlay/releases/downloa
 
 WORKDIR ${S6_ROOTFS}
 RUN <<EOS sh
-  wget -P ${DOWNLOAD_DIR} \
-    ${DOWNLOAD_URL}/s6-overlay-noarch.tar.xz \
-    ${DOWNLOAD_URL}/s6-overlay-${TARGETARCH}.tar.xz
-  tar -C ./ -xJf ${DOWNLOAD_DIR}/s6-overlay-noarch.tar.xz
-  tar -C ./ -xJf ${DOWNLOAD_DIR}/s6-overlay-${TARGETARCH}.tar.xz
+  mkdir -p ${DOWNLOAD_DIR}
+  wget -P ${DOWNLOAD_DIR} "${DOWNLOAD_URL}/s6-overlay-noarch.tar.xz"
+  tar -C ./ -xJf "${DOWNLOAD_DIR}/s6-overlay-noarch.tar.xz"
+
+  case "${TARGETARCH:-__EMPTY__}" in
+    "amd64")
+      wget -P ${DOWNLOAD_DIR} "${DOWNLOAD_URL}/s6-overlay-x86_64.tar.xz"
+      tar -C ./ -xJf "${DOWNLOAD_DIR}/s6-overlay-x86_64.tar.xz"
+      ;;
+    "arm64")
+      wget -P ${DOWNLOAD_DIR} "${DOWNLOAD_URL}/s6-overlay-aarch64.tar.xz"
+      tar -C ./ -xJf "${DOWNLOAD_DIR}/s6-overlay-aarch64.tar.xz"
+      ;;
+    *)
+      echo "WARN: Unsupported architecture: ${TARGETARCH}"
+      wget -P ${DOWNLOAD_DIR} "${DOWNLOAD_URL}/s6-overlay-$(uname -m).tar.xz"
+      tar -C ./ -xJf "${DOWNLOAD_DIR}/s6-overlay-$(uname -m).tar.xz"
+      ;;
+  esac
+
   rm -rf ${DOWNLOAD_DIR}
 EOS
 

--- a/data/s6-overlay/s6-rc.d/comfyui/run
+++ b/data/s6-overlay/s6-rc.d/comfyui/run
@@ -30,7 +30,7 @@ case -i ${ARCH}
     exec python -u ${COMFYUI_PATH}/main.py --cpu ${OPTIONS}
   }
 
-  "^amd64$" {
+  "^x86_64$" {
     exec python -u ${COMFYUI_PATH}/main.py ${OPTIONS}
   }
 }


### PR DESCRIPTION
`Containerfile` をビルド＆プッシュする GitHub Workflow を作成。
`buildah` でローカル動作確認したので CI でもビルドに `buildah` を利用する。 
また `main` ブランチへの Pull Request 時はコンテナレジストリにプッシュしない。

- ci(containerfile): Add LABEL
   コンテナイメージをリポジトリにリンク。

- revert(containerfile): Delete LABEL
  GitHub Actions の `docker/metadata-action` でラベルを付与できるため、 _Containerfile_ での記述は削除した。

- fix(s6): Fix archtechture with uname command
  64bitマシンで `uname` コマンドから得られるハードウェア情報を勘違いしていたのを修正。

- fix(workflow): IMAGE_NAME converted to lowercase
  `redhat-actions/buildah-build` の `extra-args` プロパティにおいて、 コンテナイメージ名を _lowercase_ に変換しておく必要があったため。