### PR TITLE
fix(workflow): Add security-events permission

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -127,6 +127,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # セキュリティスキャン結果のアップロード許可
+      security-events: write
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.
       id-token: write


### PR DESCRIPTION
`security-events: write` 権限がジョブに指定してなかったのを修正。