### PR TITLE
fix(trivy): Disable scan onto main 

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -194,6 +194,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=linux_${{ matrix.arch }}
 
       - name: Run Trivy build image scan
+        if: ${{ github.base_ref != 'main' }}
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
         env:
           # https://github.com/aquasecurity/trivy-action/issues/279#issuecomment-1925050674
@@ -219,6 +220,7 @@ jobs:
       # Upload a trivy report for code scanning
       # https://github.com/github/codeql-action/blob/v3.29.2/upload-sarif/action.yml
       - name: Upload scaned report
+        if: ${{ github.base_ref != 'main' }}
         uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           sarif_file: ${{ env.TRIVY_OUTPUT_FILE }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -192,9 +192,6 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           cache-from: type=gha,scope=linux_${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=linux_${{ matrix.arch }}
-          # Dockerデーモンにイメージを保存
-          # 単一プラットフォームにしか対応していないことに注意
-          load: ${{ github.base_ref == 'main' }}
 
       - name: Run Trivy build image scan
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0


### PR DESCRIPTION

エラー解消に時間がかかり、すでに `develop` ブランチでスキャンしているため、
`main` ブランチへのプルリクエスト時には `Trivy` によるスキャンを無効化して運用する。

- Revert "fix(build): Add load when no push (#12)"
  `docker/metadata-action` で _annotation_ を設定しているが、
  `load` パラメータによる単一プラットフォーム出力では _annotation_ に対応できないのでエラーが発生する。