### PR TITLE
refactor(docker): Improved to build and push the OCI image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -212,7 +212,6 @@ jobs:
       # Login against a Docker registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: ${{ ! always() }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ github.actor }}
@@ -273,18 +272,8 @@ jobs:
           category: trivy-image-${{ matrix.arch }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to ${{ env.REGISTRY }} on Skopeo
-        id: login-skopeo
-        if: ${{ github.base_ref != 'main' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >-
-          skopeo login ${{ env.REGISTRY }}
-          --username ${{ github.repository_owner }}
-          --password "${GH_TOKEN}"
-
       - name: Push a container image to ${{ env.REGISTRY }}
-        if: ${{ steps.login-skopeo.conclusion == 'success' }}
+        if: ${{ github.base_ref != 'main' }}
         env:
           CONTAINER_REF: '${{ env.REGISTRY }}/${{ needs.container-meta.outputs.image_ref }}-${{ matrix.arch }}'
         run: |
@@ -300,10 +289,6 @@ jobs:
           DOCKER_REF="ttl.sh/${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}:1h"
           skopeo copy oci:${{ env.OCI_EXPORT }} "docker://${DOCKER_REF}"
           echo "Pushed: ${DOCKER_REF}"
-
-      - name: Logout on Skopeo
-        if: ${{ (! cancelled()) && steps.login-skopeo.outcome == 'success' }}
-        run: skopeo logout ${{ env.REGISTRY }}
 
       # Install the cosign tool except on PR
       # If PR to main branch, skip.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -178,11 +178,30 @@ jobs:
       id-token: write
     env:
       TRIVY_OUTPUT_FILE: trivy_report.sarif
-      OCI_EXPORT: oci-${{ github.run_id }}
+      DOCKER_OUTPUT_DIR: /mnt/oci
+      # 出力するOCIレイアウトイメージのパス。step 内で値を定義する。
+      OCI_EXPORT: ''
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # コンテナイメージ出力用の tmpfs ディスクを作成する
+      - name: Set up tmpfs for output image
+        id: tmpfs
+        run: |
+          echo "--- Create tmpfs ---"
+          sudo mkdir ${{ env.DOCKER_OUTPUT_DIR }}
+          sudo mount -t tmpfs -o size=7G tmpfs ${{ env.DOCKER_OUTPUT_DIR }}
+          echo ""
+          echo "--- Disk info ---"
+          df -h
+          sudo lsblk -d -o name,rota
+          echo ""
+          echo "--- CPU/Mem info ---"
+          free -h
+
+          echo "OCI_EXPORT=${{ env.DOCKER_OUTPUT_DIR }}/oci-${{ github.run_id }}" >> "$GITHUB_ENV"
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -111,10 +111,54 @@ jobs:
               exit 10 ;;
           esac
 
+  # コンテナイメージ用のメタデータを出力
+  container-meta:
+    name: Outputs docker metadata
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tags: ${{ steps.meta.outputs.tags }}
+      labels: ${{ steps.meta.outputs.labels }}
+      annotations: ${{ steps.meta.outputs.annotations }}
+      image_ref: ${{ steps.extract.outputs.image_ref }}
+    permissions:
+      contents: read
+
+    steps:
+      # Extract metadata (tags, labels) for Container
+      # https://github.com/docker/metadata-action
+      - name: Extract container metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        with:
+          # `images` property is converted to lowercase
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=edge,branch=develop
+            type=ref,event=pr
+          labels: |
+            org.opencontainers.image.title=My ComfyUI Container
+            org.opencontainers.image.description=REST API server with ComfyUI backend
+            maintainer=${{ github.repository_owner }}
+          annotations: |
+            org.opencontainers.image.description=REST API server with ComfyUI backend with multi architecture
+
+      - name: Extract image reference
+        id: extract
+        run: |
+          echo "image_ref=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> "$GITHUB_OUTPUT"
+
   # PR先が main ブランチの場合はレジストリにプッシュしない
   build-multiarch:
     name: Build and Push multi-architecture image
-    needs: lint-containerfile
+    needs:
+      - lint-containerfile
+      - container-meta
     strategy:
       fail-fast: false
       matrix:
@@ -156,29 +200,6 @@ jobs:
           password: ${{ github.token }}
           registry: ${{ env.REGISTRY }}
 
-      # Extract metadata (tags, labels) for Container
-      # https://github.com/docker/metadata-action
-      - name: Extract container metadata
-        id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
-        env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
-        with:
-          # `images` property is converted to lowercase
-          images: ${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=edge,branch=develop
-            type=ref,event=pr
-          labels: |
-            org.opencontainers.image.title=My ComfyUI Container
-            org.opencontainers.image.description=REST API server with ComfyUI backend
-            maintainer=${{ github.repository_owner }}
-          annotations: |
-            org.opencontainers.image.description=REST API server with ComfyUI backend with multi architecture
-
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build Docker image
@@ -187,14 +208,14 @@ jobs:
         env:
           DOCKER_BUILD_RECORD_RETENTION_DAYS: 5
           CONTAINER_OUTPUTS_ANNOTATION: >
-            annotation.org.opencontainers.image.ref.name=${{ steps.meta.outputs.version }}-${{ matrix.arch }}
+            annotation.org.opencontainers.image.ref.name=${{ needs.container-meta.outputs.version }}-${{ matrix.arch }}
         with:
           context: .
           file: Containerfile
           push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
+          tags: ${{ needs.container-meta.outputs.tags }}
+          labels: ${{ needs.container-meta.outputs.labels }}
+          annotations: ${{ needs.container-meta.outputs.annotations }}
           platforms: linux/${{ matrix.arch }}
           # https://docs.docker.com/build/exporters/oci-docker/
           outputs: 'type=oci,dest=${{ env.OCI_EXPORT }},tar=false,${{ env.CONTAINER_OUTPUTS_ANNOTATION }}'
@@ -246,7 +267,7 @@ jobs:
       - name: Push a container image to ${{ env.REGISTRY }}
         if: ${{ steps.login-skopeo.conclusion == 'success' }}
         env:
-          CONTAINER_REF: '${{ env.REGISTRY }}/${{ fromJSON(steps.meta.outputs.json).tags[0] }}-${{ matrix.arch }}'
+          CONTAINER_REF: '${{ env.REGISTRY }}/${{ needs.container-meta.outputs.image_ref }}-${{ matrix.arch }}'
         run: |
           skopeo copy oci:${{ env.OCI_EXPORT }} "docker://${CONTAINER_REF}"
 
@@ -285,7 +306,7 @@ jobs:
         if: ${{ steps.setup-cosign.outcome == 'success' }}
         env:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
-          TAGS: ${{ steps.meta.outputs.tags }}
+          TAGS: ${{ needs.container-meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -134,6 +134,7 @@ jobs:
       id-token: write
     env:
       TRIVY_OUTPUT_FILE: trivy_report.sarif
+      OCI_EXPORT: oci-${{ github.run_id }}
 
     steps:
       - name: Checkout repository
@@ -148,6 +149,7 @@ jobs:
       # Login against a Docker registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
+        if: ${{ ! always() }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ github.actor }}
@@ -163,7 +165,7 @@ jobs:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           # `images` property is converted to lowercase
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -179,22 +181,27 @@ jobs:
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
+      - name: Build Docker image
         id: build-and-push
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        env:
+          DOCKER_BUILD_RECORD_RETENTION_DAYS: 5
+          CONTAINER_OUTPUTS_ANNOTATION: >
+            annotation.org.opencontainers.image.ref.name=${{ steps.meta.outputs.version }}-${{ matrix.arch }}
         with:
           context: .
           file: Containerfile
-          push: ${{ github.base_ref != 'main' }}
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           platforms: linux/${{ matrix.arch }}
+          # https://docs.docker.com/build/exporters/oci-docker/
+          outputs: 'type=oci,dest=${{ env.OCI_EXPORT }},tar=false,${{ env.CONTAINER_OUTPUTS_ANNOTATION }}'
           cache-from: type=gha,scope=linux_${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=linux_${{ matrix.arch }}
 
       - name: Run Trivy build image scan
-        if: ${{ github.base_ref != 'main' }}
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
         env:
           # https://github.com/aquasecurity/trivy-action/issues/279#issuecomment-1925050674
@@ -203,7 +210,7 @@ jobs:
           scan-type: image
           # python パッケージが多いのと事前にファイルシステムでチェックしてるため secret は除外する
           scanners: vuln
-          image-ref: ${{ fromJson(steps.meta.outputs.json).tags[0] }}
+          input: ${{ env.OCI_EXPORT }}
           format: sarif
           output: ${{ env.TRIVY_OUTPUT_FILE }}
           severity: CRITICAL,HIGH
@@ -220,18 +227,50 @@ jobs:
       # Upload a trivy report for code scanning
       # https://github.com/github/codeql-action/blob/v3.29.2/upload-sarif/action.yml
       - name: Upload scaned report
-        if: ${{ github.base_ref != 'main' }}
         uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           sarif_file: ${{ env.TRIVY_OUTPUT_FILE }}
           category: trivy-image-${{ matrix.arch }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to ${{ env.REGISTRY }} on Skopeo
+        id: login-skopeo
+        if: ${{ github.base_ref != 'main' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          skopeo login ${{ env.REGISTRY }}
+          --username ${{ github.repository_owner }}
+          --password "${GH_TOKEN}"
+
+      - name: Push a container image to ${{ env.REGISTRY }}
+        if: ${{ steps.login-skopeo.conclusion == 'success' }}
+        env:
+          CONTAINER_REF: '${{ env.REGISTRY }}/${{ fromJSON(steps.meta.outputs.json).tags[0] }}-${{ matrix.arch }}'
+        run: |
+          skopeo copy oci:${{ env.OCI_EXPORT }} "docker://${CONTAINER_REF}"
+
+          echo "--- Pushed Info ---"
+          echo "Pushed: ${CONTAINER_REF}"
+          skopeo inspect "docker://${CONTAINER_REF}" | jq 'del(.Layers, .LayersData, .Env)'
+
+      - name: Push container image to ttl.sh
+        if: ${{ ! always() }}
+        run: |
+          DOCKER_REF="ttl.sh/${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}:1h"
+          skopeo copy oci:${{ env.OCI_EXPORT }} "docker://${DOCKER_REF}"
+          echo "Pushed: ${DOCKER_REF}"
+
+      - name: Logout on Skopeo
+        if: ${{ (! cancelled()) && steps.login-skopeo.outcome == 'success' }}
+        run: skopeo logout ${{ env.REGISTRY }}
+
       # Install the cosign tool except on PR
       # If PR to main branch, skip.
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
-        if: ${{ github.base_ref != 'main' }}
+        id: setup-cosign
+        if: ${{ ! always() }}
         uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
         with:
           cosign-release: 'v2.2.4'
@@ -243,7 +282,7 @@ jobs:
       # If PR to main branch, skip.
       # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
-        if: ${{ github.base_ref != 'main' }}
+        if: ${{ steps.setup-cosign.outcome == 'success' }}
         env:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           TAGS: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -178,30 +178,29 @@ jobs:
       id-token: write
     env:
       TRIVY_OUTPUT_FILE: trivy_report.sarif
-      DOCKER_OUTPUT_DIR: /mnt/oci
-      # 出力するOCIレイアウトイメージのパス。step 内で値を定義する。
-      OCI_EXPORT: ''
+      # 出力するOCIレイアウトイメージのパス
+      OCI_EXPORT: ${{ github.workspace }}/build/oci-${{ github.run_id }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # コンテナイメージ出力用の tmpfs ディスクを作成する
-      - name: Set up tmpfs for output image
+      # コンテナイメージ出力用のディレクトリを作成する
+      - name: Set up a directory for output image
         id: tmpfs
         run: |
-          echo "--- Create tmpfs ---"
-          sudo mkdir ${{ env.DOCKER_OUTPUT_DIR }}
-          sudo mount -t tmpfs -o size=7G tmpfs ${{ env.DOCKER_OUTPUT_DIR }}
-          echo ""
           echo "--- Disk info ---"
           df -h
-          sudo lsblk -d -o name,rota
           echo ""
-          echo "--- CPU/Mem info ---"
+          sudo lsblk -d -o name,rota
+
+          echo "" "--- CPU/Mem info ---"
           free -h
 
-          echo "OCI_EXPORT=${{ env.DOCKER_OUTPUT_DIR }}/oci-${{ github.run_id }}" >> "$GITHUB_ENV"
+          echo "" "--- Create a directory ---"
+          create_dir=$(dirname ${{ env.OCI_EXPORT }})
+          mkdir "${create_dir}"
+          echo "created to: ${create_dir}"
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -236,9 +236,18 @@ jobs:
           annotations: ${{ needs.container-meta.outputs.annotations }}
           platforms: linux/${{ matrix.arch }}
           # https://docs.docker.com/build/exporters/oci-docker/
-          outputs: 'type=oci,dest=${{ env.OCI_EXPORT }},tar=false,${{ env.CONTAINER_OUTPUTS_ANNOTATION }}'
+          outputs: |
+            type=oci,dest=${{ env.OCI_EXPORT }},tar=false,compression=zstd,compression-level=3,${{ env.CONTAINER_OUTPUTS_ANNOTATION }}
           cache-from: type=gha,scope=linux_${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=linux_${{ matrix.arch }}
+
+      - name: Check the output image
+        run: |
+          echo "--- Size ---"
+          du -h -s ${{ env.OCI_EXPORT }}
+
+          echo "" "--- Inspect image ---"
+          skopeo inspect oci:${{ env.OCI_EXPORT }}
 
       - name: Run Trivy build image scan
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
@@ -272,12 +281,17 @@ jobs:
           category: trivy-image-${{ matrix.arch }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Push the build-image with an architecture-tag
       - name: Push a container image to ${{ env.REGISTRY }}
         if: ${{ github.base_ref != 'main' }}
         env:
           CONTAINER_REF: '${{ env.REGISTRY }}/${{ needs.container-meta.outputs.image_ref }}-${{ matrix.arch }}'
         run: |
-          skopeo copy oci:${{ env.OCI_EXPORT }} "docker://${CONTAINER_REF}"
+          skopeo copy \
+            --dest-compress-format zstd \
+            --dest-compress-level 10 \
+            oci:${{ env.OCI_EXPORT }} \
+            "docker://${CONTAINER_REF}"
 
           echo "--- Pushed Info ---"
           echo "Pushed: ${CONTAINER_REF}"


### PR DESCRIPTION
_GitHub Container Registry_ にプッシュしたイメージが煩雑になるのを防ぐため、プッシュ方法を変更する。
ビルドとプッシュを行うステップを分ける。
プッシュしない場合でも `trivy` でスキャンできるように OCI イメージレイアウトをディレクトリ構造で出力する。
その後、その OCI ディレクトリをプッシュする。

- fix(docker): Fix to export OCI image layer directory
  `trivy` は OCI アーカイブ (.tar) を理解できない。
  よって代わりに OCI イメージレイアウトをディレクトリ構造として出力し、
  そのディレクトリパスを `trivy` に渡す。

- fix(skopeo): Disabled ttl.sh
  イメージが大きいせいか、一時コンテナレジストリである `ttl.sh` へのプッシュに失敗する。
  プルリクエスト時でも `ghcr.io` にプッシュする方針に変更。

- refactor(skopeo): Show an info pushed image
  プッシュしたイメージの情報を表示。

- fix(docker): Disable docker login
  `docker` でプッシュしなくなったので無効化。

- refactor(meta): Isolate the metadata-action
  `strategy.matrix` を利用しているジョブからコンテナイメージ用のメタデータ生成を分離して効率化。
