### PR TITLE
refactor(docker): Improved to build and push the image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -164,7 +164,7 @@ jobs:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest
         with:
           # `images` property is converted to lowercase
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: suffix=-${{ matrix.arch }}
           tags: |
             type=semver,pattern={{version}}
@@ -199,8 +199,8 @@ jobs:
         with:
           context: .
           file: Containerfile
-          push: false
-          load: true
+          push: ${{ github.base_ref != 'main' }}
+          load: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: |-
@@ -213,6 +213,7 @@ jobs:
 
       - name: Run Trivy build image scan
         id: trivy
+        if: ${{ github.base_ref != 'main' }}
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
         env:
           # https://github.com/aquasecurity/trivy-action/issues/279#issuecomment-1925050674
@@ -247,7 +248,7 @@ jobs:
 
       - name: Login to ${{ env.REGISTRY }} on Skopeo
         id: login-skopeo
-        if: ${{ github.base_ref != 'main' }}
+        if: ${{ steps.trivy.outcome == 'success' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
@@ -255,26 +256,14 @@ jobs:
           --username ${{ github.repository_owner }}
           --password "${GH_TOKEN}"
 
-      - name: Push a container image to ${{ env.REGISTRY }}
+      - name: Defined to a multi-platform image
         if: ${{ steps.login-skopeo.conclusion == 'success' }}
         env:
           CONTAINER_PUSH_TO: ${{ steps.meta-append.outputs.push_to }}
         run: |
-          skopeo copy \
-            docker-daemon:${{ steps.meta-append.outputs.ref_name }} \
-            "docker://${CONTAINER_PUSH_TO}"
-
           echo "--- Pushed Info ---"
           echo "Pushed: ${CONTAINER_PUSH_TO}"
           skopeo inspect "docker://${CONTAINER_PUSH_TO}" | jq 'del(.Layers, .LayersData, .Env)'
-
-      - name: Push container image to ttl.sh
-        if: ${{ ! always() }}
-        run: |
-          DOCKER_REF="ttl.sh/${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}:1h"
-          skopeo copy docker-daemon:${{ steps.meta-append.outputs.ref_name }} "docker://${DOCKER_REF}"
-
-          echo "Pushed: ${DOCKER_REF}"
 
       - name: Logout on Skopeo
         if: ${{ (! cancelled()) && steps.login-skopeo.outcome == 'success' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -143,12 +143,10 @@ jobs:
     env:
       TRIVY_OUTPUT_FILE: trivy_report.sarif
     outputs:
-      # プッシュしたアーキテクチャごとのイメージ List
-      pushed_tags: >
-        [
-          "${{ steps.export-meta.outputs.pushed_amd64 }}",
-          "${{ steps.export-meta.outputs.pushed_arm64 }}"
-        ]
+      # プッシュしたアーキテクチャごとのイメージ
+      # JSON 形式などでまとめようとすると1つしか代入されなかった。
+      tag_amd64: ${{ steps.export-meta.outputs.pushed_amd64 }}
+      tag_arm64: ${{ steps.export-meta.outputs.pushed_arm64 }}
 
     steps:
       - name: Checkout repository
@@ -338,7 +336,11 @@ jobs:
         id: manifest
         env:
           MANIFEST_NAME: 'mylist:${{ steps.meta.outputs.version }}'
-          PUSHED_TAGS: ${{ needs.build-image.outputs.pushed_tags }}
+          PUSHED_TAGS: >
+            [
+            "${{ needs.build-image.outputs.tag_amd64 }}",
+            "${{ needs.build-image.outputs.tag_arm64 }}"
+            ]
           # 目的のマルチプラットフォームイメージ
           MP_IMAGE: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
         run: |
@@ -346,13 +348,14 @@ jobs:
 
           pushed_tags=$(echo "${PUSHED_TAGS}" | jq -r '.[]')
           while read -r image; do
+            echo "add ${image}"
             buildah manifest add \
               --annotation "org.opencontainers.image.description=REST API server with ComfyUI backend with multi architecture" \
               "${MANIFEST_NAME}" \
               "docker://${image}"
           done <<< "${pushed_tags}"
 
-          buildah manifest push --all "${MANIFEST_NAME}" "${MP_IMAGE}"
+          buildah manifest push --all "${MANIFEST_NAME}" "docker://${MP_IMAGE}"
 
           echo "pushed_tags=${pushed_tags}" >> "$GITHUB_OUTPUT"
           echo "mp_image=${MP_IMAGE}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -144,9 +144,11 @@ jobs:
       TRIVY_OUTPUT_FILE: trivy_report.sarif
     outputs:
       # プッシュしたアーキテクチャごとのイメージ List
-      pushed_tags: |
-        ${{ steps.export-meta.outputs.pushed_amd64 }}
-        ${{ steps.export-meta.outputs.pushed_arm64 }}
+      pushed_tags: >
+        [
+          "${{ steps.export-meta.outputs.pushed_amd64 }}",
+          "${{ steps.export-meta.outputs.pushed_arm64 }}"
+        ]
 
     steps:
       - name: Checkout repository
@@ -342,15 +344,17 @@ jobs:
         run: |
           buildah manifest create ${{ env.MANIFEST_NAME }}
 
+          pushed_tags=$(echo "${PUSHED_TAGS}" | jq -r '.[]')
           while read -r image; do
             buildah manifest add \
               --annotation "org.opencontainers.image.description=REST API server with ComfyUI backend with multi architecture" \
               "${MANIFEST_NAME}" \
               "docker://${image}"
-          done <<< "${PUSHED_TAGS}"
+          done <<< "${pushed_tags}"
 
           buildah manifest push --all "${MANIFEST_NAME}" "${MP_IMAGE}"
 
+          echo "pushed_tags=${pushed_tags}" >> "$GITHUB_OUTPUT"
           echo "mp_image=${MP_IMAGE}" >> "$GITHUB_OUTPUT"
 
       # 複数のタグを付与する場合の処理

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -114,7 +114,8 @@ jobs:
   # PR先が main ブランチの場合はレジストリにプッシュしない
   build-multiarch:
     name: Build and Push multi-architecture image
-    needs: lint-containerfile
+    needs:
+      - lint-containerfile
     strategy:
       fail-fast: false
       matrix:
@@ -163,7 +164,8 @@ jobs:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           # `images` property is converted to lowercase
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAME }}
+          flavor: suffix=-${{ matrix.arch }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -177,24 +179,40 @@ jobs:
           annotations: |
             org.opencontainers.image.description=REST API server with ComfyUI backend with multi architecture
 
+      - name: Append metadata
+        id: meta-append
+        env:
+          IMAGE_VERSION: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        run: |
+          echo "ref_name=${IMAGE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "push_to=${{ env.REGISTRY }}/${IMAGE_VERSION}" >> "$GITHUB_OUTPUT"
+
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        env:
+          DOCKER_BUILD_RECORD_RETENTION_DAYS: 5
+          CONTAINER_IMAGE_REF: >
+            org.opencontainers.image.ref.name=${{ steps.meta-append.outputs.ref_name }}
         with:
           context: .
           file: Containerfile
-          push: ${{ github.base_ref != 'main' }}
+          push: false
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
+          annotations: |-
+            ${{ steps.meta.outputs.annotations }}
+            index:${{ env.CONTAINER_IMAGE_REF }}
           platforms: linux/${{ matrix.arch }}
+          # https://docs.docker.com/build/exporters/oci-docker/
           cache-from: type=gha,scope=linux_${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=linux_${{ matrix.arch }}
 
       - name: Run Trivy build image scan
-        if: ${{ github.base_ref != 'main' }}
+        id: trivy
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
         env:
           # https://github.com/aquasecurity/trivy-action/issues/279#issuecomment-1925050674
@@ -203,7 +221,7 @@ jobs:
           scan-type: image
           # python パッケージが多いのと事前にファイルシステムでチェックしてるため secret は除外する
           scanners: vuln
-          image-ref: ${{ fromJson(steps.meta.outputs.json).tags[0] }}
+          image-ref: ${{ steps.meta-append.outputs.ref_name }}
           format: sarif
           output: ${{ env.TRIVY_OUTPUT_FILE }}
           severity: CRITICAL,HIGH
@@ -220,18 +238,54 @@ jobs:
       # Upload a trivy report for code scanning
       # https://github.com/github/codeql-action/blob/v3.29.2/upload-sarif/action.yml
       - name: Upload scaned report
-        if: ${{ github.base_ref != 'main' }}
+        if: ${{ steps.trivy.outcome == 'success' }}
         uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           sarif_file: ${{ env.TRIVY_OUTPUT_FILE }}
           category: trivy-image-${{ matrix.arch }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to ${{ env.REGISTRY }} on Skopeo
+        id: login-skopeo
+        if: ${{ github.base_ref != 'main' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          skopeo login ${{ env.REGISTRY }}
+          --username ${{ github.repository_owner }}
+          --password "${GH_TOKEN}"
+
+      - name: Push a container image to ${{ env.REGISTRY }}
+        if: ${{ steps.login-skopeo.conclusion == 'success' }}
+        env:
+          CONTAINER_PUSH_TO: ${{ steps.meta-append.outputs.push_to }}
+        run: |
+          skopeo copy \
+            docker-daemon:${{ steps.meta-append.outputs.ref_name }} \
+            "docker://${CONTAINER_PUSH_TO}"
+
+          echo "--- Pushed Info ---"
+          echo "Pushed: ${CONTAINER_PUSH_TO}"
+          skopeo inspect "docker://${CONTAINER_PUSH_TO}" | jq 'del(.Layers, .LayersData, .Env)'
+
+      - name: Push container image to ttl.sh
+        if: ${{ ! always() }}
+        run: |
+          DOCKER_REF="ttl.sh/${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}:1h"
+          skopeo copy docker-daemon:${{ steps.meta-append.outputs.ref_name }} "docker://${DOCKER_REF}"
+
+          echo "Pushed: ${DOCKER_REF}"
+
+      - name: Logout on Skopeo
+        if: ${{ (! cancelled()) && steps.login-skopeo.outcome == 'success' }}
+        run: skopeo logout ${{ env.REGISTRY }}
+
       # Install the cosign tool except on PR
       # If PR to main branch, skip.
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
-        if: ${{ github.base_ref != 'main' }}
+        id: setup-cosign
+        if: ${{ ! always() }}
         uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
         with:
           cosign-release: 'v2.2.4'
@@ -243,7 +297,7 @@ jobs:
       # If PR to main branch, skip.
       # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
-        if: ${{ github.base_ref != 'main' }}
+        if: ${{ steps.setup-cosign.outcome == 'success' }}
         env:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           TAGS: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -304,7 +304,7 @@ jobs:
     name: Post pushed images
     if: ${{ github.base_ref != 'main' }}
     needs: build-image
-    runs-on: ubuntu24.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -161,7 +161,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest
         with:
           # `images` property is converted to lowercase
           images: ${{ env.IMAGE_NAME }}
@@ -205,7 +205,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: |-
             ${{ steps.meta.outputs.annotations }}
-            index:${{ env.CONTAINER_IMAGE_REF }}
+            manifest:${{ env.CONTAINER_IMAGE_REF }}
           platforms: linux/${{ matrix.arch }}
           # https://docs.docker.com/build/exporters/oci-docker/
           cache-from: type=gha,scope=linux_${{ matrix.arch }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -308,15 +308,18 @@ jobs:
     permissions:
       contents: read
       packages: write
+    timeout-minutes: 5
 
     steps:
       # https://github.com/redhat-actions/podman-login/tree/v1.7
       - name: Login to ${{ env.REGISTRY }} with Podman
         id: login
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        env:
+          LOGIN_REGISTRY: ${{ format('{0}/{1}', env.REGISTRY, github.repository_owner) }}
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
+          registry: ${{ env.LOGIN_REGISTRY }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Container

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,6 +23,13 @@ env:
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
+  # Input for docker/metadata-action:tags
+  METADATA_INPUT_TAGS: |
+    type=semver,pattern={{version}}
+    type=semver,pattern={{major}}.{{minor}}
+    type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+    type=edge,branch=develop
+    type=ref,event=pr
 
 jobs:
   lint-containerfile:
@@ -112,8 +119,8 @@ jobs:
           esac
 
   # PR先が main ブランチの場合はレジストリにプッシュしない
-  build-multiarch:
-    name: Build and Push multi-architecture image
+  build-image:
+    name: Build and Push the image
     needs:
       - lint-containerfile
     strategy:
@@ -135,6 +142,11 @@ jobs:
       id-token: write
     env:
       TRIVY_OUTPUT_FILE: trivy_report.sarif
+    outputs:
+      # プッシュしたアーキテクチャごとのイメージ List
+      pushed_tags: |
+        ${{ steps.export-meta.outputs.pushed_amd64 }}
+        ${{ steps.export-meta.outputs.pushed_arm64 }}
 
     steps:
       - name: Checkout repository
@@ -166,26 +178,19 @@ jobs:
           # `images` property is converted to lowercase
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: suffix=-${{ matrix.arch }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=edge,branch=develop
-            type=ref,event=pr
+          tags: ${{ env.METADATA_INPUT_TAGS }}
           labels: |
             org.opencontainers.image.title=My ComfyUI Container
             org.opencontainers.image.description=REST API server with ComfyUI backend
             maintainer=${{ github.repository_owner }}
-          annotations: |
-            org.opencontainers.image.description=REST API server with ComfyUI backend with multi architecture
 
+      # 後々のステップで使う、代表となるタグを抽出
       - name: Append metadata
         id: meta-append
         env:
-          IMAGE_VERSION: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          SINGLE_PUSH_TO: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
         run: |
-          echo "ref_name=${IMAGE_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "push_to=${{ env.REGISTRY }}/${IMAGE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "push_to=${SINGLE_PUSH_TO}" >> "$GITHUB_OUTPUT"
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -195,7 +200,7 @@ jobs:
         env:
           DOCKER_BUILD_RECORD_RETENTION_DAYS: 5
           CONTAINER_IMAGE_REF: >
-            org.opencontainers.image.ref.name=${{ steps.meta-append.outputs.ref_name }}
+            org.opencontainers.image.ref.name=${{ steps.meta-append.outputs.push_to }}
         with:
           context: .
           file: Containerfile
@@ -222,7 +227,7 @@ jobs:
           scan-type: image
           # python パッケージが多いのと事前にファイルシステムでチェックしてるため secret は除外する
           scanners: vuln
-          image-ref: ${{ steps.meta-append.outputs.ref_name }}
+          image-ref: ${{ steps.meta-append.outputs.push_to }}
           format: sarif
           output: ${{ env.TRIVY_OUTPUT_FILE }}
           severity: CRITICAL,HIGH
@@ -246,28 +251,24 @@ jobs:
           category: trivy-image-${{ matrix.arch }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to ${{ env.REGISTRY }} on Skopeo
-        id: login-skopeo
-        if: ${{ steps.trivy.outcome == 'success' }}
+      # ジョブ出力用の変数設定
+      # マトリックスジョブに対応するため、出力変数名にマトリックスの値を使用。
+      - name: Export the ${{ matrix.arch }} tag
+        id: export-meta
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >-
-          skopeo login ${{ env.REGISTRY }}
-          --username ${{ github.repository_owner }}
-          --password "${GH_TOKEN}"
+          PUSH_TO: ${{ steps.meta-append.outputs.push_to }}
+        run: |
+          echo "pushed_${{ matrix.arch }}=${PUSH_TO}" >> "$GITHUB_OUTPUT"
 
-      - name: Defined to a multi-platform image
-        if: ${{ steps.login-skopeo.conclusion == 'success' }}
+      # プッシュしたイメージの情報表示
+      - name: Inspect a pushed image
+        if: ${{ steps.trivy.outcome == 'success' }}
         env:
           CONTAINER_PUSH_TO: ${{ steps.meta-append.outputs.push_to }}
         run: |
           echo "--- Pushed Info ---"
           echo "Pushed: ${CONTAINER_PUSH_TO}"
           skopeo inspect "docker://${CONTAINER_PUSH_TO}" | jq 'del(.Layers, .LayersData, .Env)'
-
-      - name: Logout on Skopeo
-        if: ${{ (! cancelled()) && steps.login-skopeo.outcome == 'success' }}
-        run: skopeo logout ${{ env.REGISTRY }}
 
       # Install the cosign tool except on PR
       # If PR to main branch, skip.
@@ -297,3 +298,76 @@ jobs:
           echo "${TAGS}" | while read -r image; do
             cosign sign --yes "${image}@${DIGEST}"
           done
+
+  # プッシュしたイメージに対する処理
+  post-pushed-images:
+    name: Post pushed images
+    if: ${{ github.base_ref != 'main' }}
+    needs: build-image
+    runs-on: ubuntu24.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # https://github.com/redhat-actions/podman-login/tree/v1.7
+      - name: Login to ${{ env.REGISTRY }} with Podman
+        id: login
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Container
+      # https://github.com/docker/metadata-action
+      - name: Extract container metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          # `images` property is converted to lowercase
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: ${{ env.METADATA_INPUT_TAGS }}
+
+      - name: Create a multi-platform manifest
+        id: manifest
+        env:
+          MANIFEST_NAME: 'mylist:${{ steps.meta.outputs.version }}'
+          PUSHED_TAGS: ${{ needs.build-image.outputs.pushed_tags }}
+          # 目的のマルチプラットフォームイメージ
+          MP_IMAGE: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        run: |
+          buildah manifest create ${{ env.MANIFEST_NAME }}
+
+          while read -r image; do
+            buildah manifest add \
+              --annotation "org.opencontainers.image.description=REST API server with ComfyUI backend with multi architecture" \
+              "${MANIFEST_NAME}" \
+              "docker://${image}"
+          done <<< "${PUSHED_TAGS}"
+
+          buildah manifest push --all "${MANIFEST_NAME}" "${MP_IMAGE}"
+
+          echo "mp_image=${MP_IMAGE}" >> "$GITHUB_OUTPUT"
+
+      # 複数のタグを付与する場合の処理
+      - name: Append tags with skopeo
+        env:
+          TAGS: ${{ fromJSON(steps.meta.outputs.json).tags }}
+        run: |
+          remain_tags="$(jq -r 'del(.[0])' <<< ${TAGS})"
+          while read -r tag; do
+            skopeo copy "docker://${{ steps.manifest.outputs.mp_image }}" "docker://${tag}"
+          done <<< "${remain_tags}"
+
+      # マルチプラットフォームイメージの確認
+      - name: Check the multi-platform image
+        env:
+          MP_IMAGE: ${{ steps.manifest.outputs.mp_image }}
+        run: |
+          echo "--- Check manifest ---"
+          buildah manifest inspect "${MP_IMAGE}"
+
+          echo "--- Check image ---"
+          skopeo inspect "docker://${MP_IMAGE}"
+


### PR DESCRIPTION
_GitHub Container Registry_ にプッシュしたイメージが煩雑になるのを防ぐため、プッシュ方法を変更する。
- ビルドとプッシュを行うステップを分け、後からマルチプラットフォームイメージ化する。
- マルチプラットフォームのためとタグなしプッシュを避けるため、タグ名にアーキテクチャを追記。
- `trivy` でスキャンできるようにローカルストアへイメージ出力する。
- `skopeo` でプッシュする。
- イメージへの署名はレジストリが煩雑になるので一旦無効化。

***

- fix(skopeo): Disabled ttl.sh イメージが大きいせいか、一時コンテナレジストリである `ttl.sh` へのプッシュに失敗する。 プルリクエスト時でも `ghcr.io` にプッシュする方針に変更。