### PR TITLE
ci(buildah): Create and push the multi-platform manifest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -411,8 +411,6 @@ jobs:
         run: |
           buildah manifest push \
             --all \
-            --compression-format zstd \
-            --compression-level 10 \
             ${{ env.MANIFEST_NAME }} \
             docker://${{ env.DIST_IMAGE }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -135,7 +135,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest
         with:
           # `images` property is converted to lowercase
           images: ${{ env.IMAGE_NAME }}
@@ -149,8 +149,6 @@ jobs:
             org.opencontainers.image.title=My ComfyUI Container
             org.opencontainers.image.description=REST API server with ComfyUI backend
             maintainer=${{ github.repository_owner }}
-          annotations: |
-            org.opencontainers.image.description=REST API server with ComfyUI backend with multi architecture
 
       - name: Extract image reference
         id: extract
@@ -158,7 +156,7 @@ jobs:
           echo "image_ref=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> "$GITHUB_OUTPUT"
 
   # PR先が main ブランチの場合はレジストリにプッシュしない
-  build-multiarch:
+  build-image:
     name: Build and Push multi-architecture image
     needs:
       - lint-containerfile
@@ -186,6 +184,11 @@ jobs:
       TRIVY_OUTPUT_FILE: trivy_report.sarif
       # 出力するOCIレイアウトイメージのパス
       OCI_EXPORT: ${{ github.workspace }}/build/oci-${{ github.run_id }}
+    outputs:
+      # プッシュしたアーキテクチャごとのイメージ
+      # JSON 形式などでまとめようとすると1つしか代入されない。
+      tag_amd64: '${{ steps.push-image.outputs.pushed_amd64 }}'
+      tag_arm64: '${{ steps.push-image.outputs.pushed_arm64 }}'
 
     steps:
       - name: Checkout repository
@@ -237,7 +240,7 @@ jobs:
           context: .
           file: Containerfile
           push: false
-          tags: ${{ needs.container-meta.outputs.tags }}
+          tags: ${{ needs.container-meta.outputs.image_ref }}-${{ matrix.arch }}
           labels: ${{ needs.container-meta.outputs.labels }}
           annotations: ${{ needs.container-meta.outputs.annotations }}
           platforms: linux/${{ matrix.arch }}
@@ -290,6 +293,7 @@ jobs:
 
       # Push the build-image with an architecture-tag
       - name: Push a container image to ${{ env.REGISTRY }}
+        id: push-image
         if: ${{ github.base_ref != 'main' }}
         timeout-minutes: 1
         env:
@@ -304,6 +308,8 @@ jobs:
           echo "--- Pushed Info ---"
           echo "Pushed: ${CONTAINER_REF}"
           skopeo inspect "docker://${CONTAINER_REF}" | jq 'del(.Layers, .LayersData, .Env)'
+
+          echo "pushed_${{ matrix.arch }}=${CONTAINER_REF}" >> "$GITHUB_OUTPUT"
 
       - name: Push container image to ttl.sh
         if: ${{ ! always() }}
@@ -340,3 +346,88 @@ jobs:
           echo "${TAGS}" | while read -r image; do
             cosign sign --yes "${image}@${DIGEST}"
           done
+
+  # プッシュしたイメージに対する処理
+  post-push-images:
+    name: Post-push images
+    if: ${{ needs.build-image.outputs.tag_amd64 != '' && needs.build-image.outputs.tag_arm64 != '' }}
+    needs:
+      - build-image
+      - container-meta
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      packages: write
+    env:
+      # 作成するマルチプラットフォームのイメージ名(<registry>/<image name>:<tag>)
+      DIST_IMAGE: '${{ needs.container-meta.outputs.image_ref }}'
+      MANIFEST_NAME: 'mylist:${{ needs.container-meta.outputs.version }}'
+
+    steps:
+      # https://github.com/redhat-actions/podman-login/tree/v1.7
+      - name: Login to ${{ env.REGISTRY }} with Podman
+        id: login
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        env:
+          LOGIN_REGISTRY: ${{ format('{0}/{1}', env.REGISTRY, github.repository_owner) }}
+        with:
+          registry: ${{ env.LOGIN_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # imageName: https://github.com/containers/image/blob/v5.36.0/docs/containers-transports.5.md
+      # buildah manifest add: https://github.com/containers/buildah/blob/v1.33.7/docs/buildah-manifest-add.1.md
+      - name: Create a multi-platform manifest
+        id: create-manifest
+        env:
+          PUSHED_TAGS: |
+            ${{ needs.build-image.outputs.tag_amd64 }}
+            ${{ needs.build-image.outputs.tag_arm64 }}
+          # 追加アノテーション
+          ANNO_DESC: org.opencontainers.image.description=REST API server with ComfyUI backend with multi architecture
+        run: |
+          buildah manifest create ${{ env.MANIFEST_NAME }}
+
+          while read -r image; do
+            echo "include ${image}"
+
+            buildah manifest add \
+              --annotation "${ANNO_DESC}" \
+              ${{ env.MANIFEST_NAME }} \
+              "docker://${image}"
+          done < <(sed '/^$/d' <<< "${PUSHED_TAGS}")
+
+      # https://github.com/containers/buildah/blob/v1.33.7/docs/buildah-manifest-push.1.md
+      - name: Push the multi-platform manifest
+        id: push-manifest
+        run: |
+          buildah manifest push \
+            --all \
+            --compression-format zstd \
+            --compression-level 10 \
+            ${{ env.MANIFEST_NAME }} \
+            docker://${{ env.DIST_IMAGE }}
+
+      # 複数のタグを付与する場合の処理
+      # https://github.com/containers/skopeo/blob/v1.13.3/docs/skopeo-copy.1.md
+      - name: Append tags with skopeo
+        env:
+          ALL_TAGS: '${{ needs.container-meta.outputs.tags }}'
+        run: |
+          remain_tags=$(sed '/^$/d; 1d' <<< "${ALL_TAGS}")
+
+          while read -r tag; do
+            echo "add tag: ${tag}"
+
+            skopeo copy "docker://${{ env.DIST_IMAGE }}" "docker://${tag}"
+          done <<< "${remain_tags}"
+
+      # マルチプラットフォームイメージの確認
+      - name: Check the multi-platform image
+        run: |
+          echo "--- Check manifest ---"
+          buildah manifest inspect "${{ env.DIST_IMAGE }}"
+
+          echo "" "--- Check image ---"
+          skopeo inspect "docker://${{ env.DIST_IMAGE }}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -414,19 +414,30 @@ jobs:
             ${{ env.MANIFEST_NAME }} \
             docker://${{ env.DIST_IMAGE }}
 
-      # 複数のタグを付与する場合の処理
-      # https://github.com/containers/skopeo/blob/v1.13.3/docs/skopeo-copy.1.md
-      - name: Append tags with skopeo
+      # 追加するタグを抽出
+      # Outputs:
+      #   tags - 追加するタグの List
+      - name: Pickup additional tags
+        id: additional-tags
         env:
           ALL_TAGS: '${{ needs.container-meta.outputs.tags }}'
         run: |
-          remain_tags=$(sed '/^$/d; 1d' <<< "${ALL_TAGS}")
+          additional_tags=$(sed '/^$/d; 1d' <<< "${ALL_TAGS}")
+          echo "tags=${additional_tags}" >> "$GITHUB_OUTPUT"
 
+      # 追加するタグがあれば、追加処理を行う
+      # https://github.com/containers/skopeo/blob/v1.13.3/docs/skopeo-copy.1.md
+      - name: Append tags with skopeo
+        # 追加のタグがなければスキップ
+        if: ${{ steps.additional-tags.outputs.tags != '' }}
+        env:
+          ADDITIONAL_TAGS: ${{ steps.additional-tags.outputs.tags }}
+        run: |
           while read -r tag; do
             echo "add tag: ${tag}"
 
             skopeo copy "docker://${{ env.DIST_IMAGE }}" "docker://${{ env.REGISTRY }}/${tag}"
-          done <<< "${remain_tags}"
+          done <<< "${ADDITIONAL_TAGS}"
 
       # マルチプラットフォームイメージの確認
       - name: Check the multi-platform image

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -361,10 +361,17 @@ jobs:
       packages: write
     env:
       # 作成するマルチプラットフォームのイメージ名(<registry>/<image name>:<tag>)
-      DIST_IMAGE: '${{ needs.container-meta.outputs.image_ref }}'
+      # step で設定する。
+      DIST_IMAGE: ''
       MANIFEST_NAME: 'mylist:${{ needs.container-meta.outputs.version }}'
 
     steps:
+      - name: Set up environment variables
+        env:
+          DIST_IMAGE: '${{ env.REGISTRY }}/${{ needs.container-meta.outputs.image_ref }}'
+        run: |
+          echo "DIST_IMAGE=${{ env.DIST_IMAGE }}" >> "$GITHUB_ENV"
+
       # https://github.com/redhat-actions/podman-login/tree/v1.7
       - name: Login to ${{ env.REGISTRY }} with Podman
         id: login
@@ -420,7 +427,7 @@ jobs:
           while read -r tag; do
             echo "add tag: ${tag}"
 
-            skopeo copy "docker://${{ env.DIST_IMAGE }}" "docker://${tag}"
+            skopeo copy "docker://${{ env.DIST_IMAGE }}" "docker://${{ env.REGISTRY }}/${tag}"
           done <<< "${remain_tags}"
 
       # マルチプラットフォームイメージの確認


### PR DESCRIPTION
マルチプラットフォームイメージのマニフェストを作成＆プッシュする _job_ を作成。

- fix: Fix to docker build settings _docker 
  build_ 時のタグやアノテーションをマルチプラットフォーム用に微調整。

- ci(docker): Set up job outputs
  アーキテクチャごとのイメージ名を変数として使えるよう設定。

***
closes #17 