### PR TITLE
fix(docker): Optimized docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -246,7 +246,7 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           # https://docs.docker.com/build/exporters/oci-docker/
           outputs: |
-            type=oci,dest=${{ env.OCI_EXPORT }},tar=false,compression=zstd,compression-level=3,${{ env.CONTAINER_OUTPUTS_ANNOTATION }}
+            type=oci,dest=${{ env.OCI_EXPORT }},tar=false,compression=zstd,compression-level=10,${{ env.CONTAINER_OUTPUTS_ANNOTATION }}
           cache-from: type=gha,scope=linux_${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=linux_${{ matrix.arch }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -170,8 +170,8 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: arm64
     runs-on: ${{ matrix.os }}
-    # maximum run time: 10 min
-    timeout-minutes: 10
+    # maximum run time: 33 min
+    timeout-minutes: 33
     permissions:
       contents: read
       packages: write
@@ -231,7 +231,7 @@ jobs:
       - name: Build Docker image
         id: build-and-push
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
-        timeout-minutes: 5
+        timeout-minutes: 20
         env:
           DOCKER_BUILD_RECORD_RETENTION_DAYS: 5
           CONTAINER_OUTPUTS_ANNOTATION: >
@@ -260,7 +260,7 @@ jobs:
 
       - name: Run Trivy build image scan
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
-        timeout-minutes: 3
+        timeout-minutes: 5
         env:
           # https://github.com/aquasecurity/trivy-action/issues/279#issuecomment-1925050674
           TRIVY_PLATFORM: linux/${{ matrix.arch }}
@@ -295,7 +295,7 @@ jobs:
       - name: Push a container image to ${{ env.REGISTRY }}
         id: push-image
         if: ${{ github.base_ref != 'main' }}
-        timeout-minutes: 1
+        timeout-minutes: 6
         env:
           CONTAINER_REF: '${{ env.REGISTRY }}/${{ needs.container-meta.outputs.image_ref }}-${{ matrix.arch }}'
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -182,6 +182,10 @@ jobs:
       id-token: write
     env:
       TRIVY_OUTPUT_FILE: trivy_report.sarif
+      # docker ビルド時のキャッシュ設定
+      # https://docs.docker.com/build/cache/backends/gha/
+      DOCKER_BUILD_CACHE_FROM: type=gha,scope=linux_${{ matrix.arch }}
+      DOCKER_BUILD_CACHE_TO: type=gha,mode=max,scope=linux_${{ matrix.arch }}
       # 出力するOCIレイアウトイメージのパス
       OCI_EXPORT: ${{ github.workspace }}/build/oci-${{ github.run_id }}
     outputs:
@@ -210,6 +214,27 @@ jobs:
           create_dir=$(dirname ${{ env.OCI_EXPORT }})
           mkdir "${create_dir}"
           echo "created to: ${create_dir}"
+
+      # プルリクエスト時、`docker/build-push-action` のキャッシュ設定をインラインキャッシュに変更
+      # GitHub Actions では現在ブランチもしくはデフォルトブランチのキャッシュしか利用できないため、
+      # キャッシュ生成を制限して GitHub Actions Caches の使用量を抑制する。
+      # (無効化したかったけどそれには `cache-to` プロパティを削除するしかなさそう)
+      - name: Change `DOCKER_BUILD_CACHE_*` to inline
+        id: cache-to
+        if: ${{ github.event_name == 'pull_request' || github.ref_name != 'develop' }}
+        env:
+          # inline キャッシュを参照できるように registry キャッシュ設定を追加
+          # https://docs.docker.com/build/ci/github-actions/cache/
+          # 複数行文字列の設定 (https://docs.github.com/ja/actions/reference/workflow-commands-for-github-actions#multiline-strings)
+          NEW_CACHE_FROM: |-
+            DOCKER_BUILD_CACHE_FROM<<EOT
+            type=registry,ref=${{ env.REGISTRY }}/${{ needs.container-meta.outputs.image_ref }}-${{ matrix.arch }}
+            ${{ env.DOCKER_BUILD_CACHE_FROM }}
+            EOT
+          NEW_CACHE_TO: type=inline
+        run: |
+          echo "${NEW_CACHE_FROM}" >> "$GITHUB_ENV"
+          echo "DOCKER_BUILD_CACHE_TO=${NEW_CACHE_TO}" >> "$GITHUB_ENV"
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
@@ -247,8 +272,8 @@ jobs:
           # https://docs.docker.com/build/exporters/oci-docker/
           outputs: |
             type=oci,dest=${{ env.OCI_EXPORT }},tar=false,compression=zstd,compression-level=10,${{ env.CONTAINER_OUTPUTS_ANNOTATION }}
-          cache-from: type=gha,scope=linux_${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=linux_${{ matrix.arch }}
+          cache-from: ${{ env.DOCKER_BUILD_CACHE_FROM }}
+          cache-to: ${{ env.DOCKER_BUILD_CACHE_TO }}
 
       - name: Check the output image
         run: |


### PR DESCRIPTION
コンテナイメージのビルド方法を調整した。

- ビルドキャッシュが無効になった場合を想定して `timeout-minutes` を延長。
- _GitHub Actions Caches_ の使用量削減のためキャッシュ生成を抑制。
    デフォルトブランチ `develop` にプッシュしたときのみ _GAC_ へキャッシュ。
    他は [_inline_ キャッシュ](https://docs.docker.com/build/cache/backends/inline/)を使う。
- 圧縮レベルを高圧縮の `10` に設定し、ビルド時間を計測してみる。 
    規定内に収まるので採用。

***
closes #24 #22 