### PR TITLE
build(github): Change branch model for semantic versioning

### DIFF
--- a/.github/.releaserc.yaml
+++ b/.github/.releaserc.yaml
@@ -4,7 +4,12 @@
 # https://github.com/semantic-release/semantic-release/blob/v24.2.7/docs/usage/configuration.md#configuration
 
 branches:
+  # Release
   - name: main
+  # Pre-release
+  - name: pre-release
+    prerelease: true
+    channel: alpha
   - name: 'test/**'
     # `prerelease: true` にすると `channel` を設定しても
     # `EPRERELEASEBRANCH A pre-release branch configuration is invalid in the `branches` configuration.`

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,9 +3,12 @@ name: Auto Release
 on:
   push:
     branches:
+      - pre-release
+      - main
+  pull_request:
+    branches:
       # https://docs.github.com/ja/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet
       - 'test/**'
-      - main
 
 jobs:
   release:
@@ -58,5 +61,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx semantic-release \
-            --dry-run
+          npx semantic-release

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,9 +6,12 @@ on:
       - develop
     # Publish semver tags as releases.
     tags:
-      # Only release tags, exclude pre-release tags
+      # Only release tags
       # https://docs.github.com/ja/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      # Pre-release tags
+      - 'v[0-9]+.[0-9]+.[0-9]+-alpha*'
+      - 'v[0-9]+.[0-9]+.[0-9]+-beta*'
   pull_request:
     # filter
     paths:
@@ -18,6 +21,7 @@ on:
       - .github/workflows/docker-publish.yml
     branches:
       - main
+      - pre-release
       - develop
 
 env:
@@ -322,7 +326,7 @@ jobs:
       # Push the build-image with an architecture-tag
       - name: Push a container image to ${{ env.REGISTRY }}
         id: push-image
-        if: ${{ github.base_ref != 'main' }}
+        if: ${{ github.base_ref != 'pre-release' && github.base_ref != 'main' }}
         timeout-minutes: 6
         env:
           CONTAINER_REF: '${{ env.REGISTRY }}/${{ needs.container-meta.outputs.image_ref }}-${{ matrix.arch }}'


### PR DESCRIPTION
セマンティックバージョニングに従う上で、プリリリースを扱う `pre-release` ブランチを新しく作成した。 
それに従って _CI_ のワークフロートリガーなどを調整。

#32 