### PR TITLE
ci: Automatically publish the release

### DIFF
--- a/.github/.releaserc.yaml
+++ b/.github/.releaserc.yaml
@@ -4,7 +4,12 @@
 # https://github.com/semantic-release/semantic-release/blob/v24.2.7/docs/usage/configuration.md#configuration
 
 branches:
+  # Release
   - name: main
+  # Pre-release
+  - name: pre-release
+    prerelease: true
+    channel: alpha
   - name: 'test/**'
     # `prerelease: true` にすると `channel` を設定しても
     # `EPRERELEASEBRANCH A pre-release branch configuration is invalid in the `branches` configuration.`

--- a/.github/.releaserc.yaml
+++ b/.github/.releaserc.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://www.schemastore.org/semantic-release.json
+
+# Configuration
+# https://github.com/semantic-release/semantic-release/blob/v24.2.7/docs/usage/configuration.md#configuration
+
+branches:
+  - name: main
+  - name: 'test/**'
+    # `prerelease: true` にすると `channel` を設定しても
+    # `EPRERELEASEBRANCH A pre-release branch configuration is invalid in the `branches` configuration.`
+    # エラーが発生する。
+    # （`prerelease: true` の場合は `name` プロパティを参照して `/` があるからエラーが起こっている、のかも）
+    prerelease: snapshot.test
+    # channel: snapshot.test
+
+plugins:
+  -
+    # https://github.com/semantic-release/commit-analyzer
+    - '@semantic-release/commit-analyzer'
+    - preset: conventionalcommits
+  -
+    # https://github.com/semantic-release/release-notes-generator
+    - '@semantic-release/release-notes-generator'
+    - preset: conventionalcommits
+  -
+    # https://github.com/semantic-release/github
+    - '@semantic-release/github'
+    - draftRelease: true
+

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,62 @@
+name: Auto Release
+
+on:
+  push:
+    branches:
+      # https://docs.github.com/ja/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet
+      - 'test/**'
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    permissions:
+      # タグ作成に書き込み権限が必要
+      contents: write
+      # リリースノート作成やIssueへのリンクに必要
+      issues: write
+      # PR へのコメントに必要
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch all history for all branches and tags
+          fetch-depth: 0
+          # Partial clone: blobless
+          filter: 'blob:none'
+
+      # https://github.com/actions/setup-node
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+
+      # https://github.com/semantic-release/semantic-release/blob/master/docs/usage/installation.md#installation
+      - name: Install semantic-release
+        env:
+          # `semantic-release` 本体
+          SEMANTIC_RELEASE: 'semantic-release@"^24.2.7"'
+          # Conventional Commits 仕様に準拠させる場合に必要なパッケージ
+          # https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits
+          CONVENTIONAL_COMMITS: 'conventional-changelog-conventionalcommits@"^9.1.0"'
+        run: |
+          npm install --save-dev ${{ env.SEMANTIC_RELEASE }} ${{ env.CONVENTIONAL_COMMITS }}
+
+      - name: Setup release config
+        env:
+          SRC_CONFIG: ${{ github.workspace }}/.github/.releaserc.yaml
+          LINK: .releaserc.yaml
+        run: |
+          ln -s  "${SRC_CONFIG}" "${LINK}"
+          ls -Alh "${LINK}"
+
+      # リリース処理
+      - name: Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npx semantic-release \
+            --dry-run

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,9 +3,12 @@ name: Auto Release
 on:
   push:
     branches:
+      - pre-release
+      - main
+  pull_request:
+    branches:
       # https://docs.github.com/ja/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet
       - 'test/**'
-      - main
 
 jobs:
   release:
@@ -58,5 +61,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx semantic-release \
-            --dry-run
+          npx semantic-release

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -145,7 +145,7 @@ jobs:
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=edge,branch=develop
             type=ref,event=pr
-            type=raw,enable=${{ github.event_name == 'pull_request' }},value=test
+            type=raw,enable=false,value=test
           labels: |
             org.opencontainers.image.title=My ComfyUI Container
             org.opencontainers.image.description=REST API server with ComfyUI backend

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,9 +6,12 @@ on:
       - develop
     # Publish semver tags as releases.
     tags:
-      # Only release tags, exclude pre-release tags
+      # Only release tags
       # https://docs.github.com/ja/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      # Pre-release tags
+      - 'v[0-9]+.[0-9]+.[0-9]+-alpha*'
+      - 'v[0-9]+.[0-9]+.[0-9]+-beta*'
   pull_request:
     # filter
     paths:
@@ -18,6 +21,7 @@ on:
       - .github/workflows/docker-publish.yml
     branches:
       - main
+      - pre-release
       - develop
 
 env:
@@ -322,7 +326,7 @@ jobs:
       # Push the build-image with an architecture-tag
       - name: Push a container image to ${{ env.REGISTRY }}
         id: push-image
-        if: ${{ github.base_ref != 'main' }}
+        if: ${{ github.base_ref != 'pre-release' && github.base_ref != 'main' }}
         timeout-minutes: 6
         env:
           CONTAINER_REF: '${{ env.REGISTRY }}/${{ needs.container-meta.outputs.image_ref }}-${{ matrix.arch }}'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,9 @@ on:
       - develop
     # Publish semver tags as releases.
     tags:
-      - 'v*.*.*'
+      # Only release tags, exclude pre-release tags
+      # https://docs.github.com/ja/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     # filter
     paths:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -145,6 +145,7 @@ jobs:
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=edge,branch=develop
             type=ref,event=pr
+            type=raw,enable=${{ github.event_name == 'pull_request' }},value=test
           labels: |
             org.opencontainers.image.title=My ComfyUI Container
             org.opencontainers.image.description=REST API server with ComfyUI backend
@@ -430,47 +431,25 @@ jobs:
               "docker://${image}"
           done < <(sed '/^$/d' <<< "${PUSHED_TAGS}")
 
+      # マルチプラットフォームイメージのプッシュ
+      # 追加するタグ (`latest`, `1` など) もここで処理する。
       # https://github.com/containers/buildah/blob/v1.33.7/docs/buildah-manifest-push.1.md
       - name: Push the multi-platform manifest
         id: push-manifest
-        run: |
-          buildah manifest push \
-            --all \
-            ${{ env.MANIFEST_NAME }} \
-            docker://${{ env.DIST_IMAGE }}
-
-      # 追加するタグを抽出
-      # Outputs:
-      #   tags - 追加するタグの List
-      - name: Pickup additional tags
-        id: additional-tags
         env:
-          ALL_TAGS: ${{ needs.container-meta.outputs.tags }}
-        run: |
-          {
-            echo 'tags<<EOT'
-            sed '/^$/d; 1d' <<< "${ALL_TAGS}"
-            echo 'EOT'
-          } >> "$GITHUB_OUTPUT"
-
-      # 追加するタグがあれば、追加処理を行う
-      # https://github.com/containers/skopeo/blob/v1.13.3/docs/skopeo-copy.1.md
-      - name: Append tags with skopeo
-        # 追加のタグがなければスキップ
-        if: ${{ steps.additional-tags.outputs.tags != '' }}
-        env:
-          ADDITIONAL_TAGS: ${{ steps.additional-tags.outputs.tags }}
+          PUSH_TAGS: ${{ needs.container-meta.outputs.tags }}
         run: |
           while read -r tag; do
             echo "add tag: ${tag}"
 
-            skopeo copy "docker://${{ env.DIST_IMAGE }}" "docker://${{ env.REGISTRY }}/${tag}"
-          done <<< "${ADDITIONAL_TAGS}"
+          buildah manifest push \
+            --all \
+            ${{ env.MANIFEST_NAME }} \
+            "docker://${{ env.REGISTRY }}/${tag}"
+          done <<< "${PUSH_TAGS}"
 
       # マルチプラットフォームイメージの確認
       - name: Check the multi-platform image
-        env:
-          ADDITIONAL_TAGS: ${{ steps.additional-tags.outputs.tags }}
         run: |
           echo "--- Check manifest ---"
           buildah manifest inspect "${{ env.DIST_IMAGE }}"


### PR DESCRIPTION
_Github Workflow_ によって自動的にタグ・リリースを付与・公開するように実装。
自動化ツールには `semantic-release` を用いた。

セマンティックバージョニングにしたがい、
- `pre-release` ブランチでプリリリース (e.g. `v1.2.3-alpha.1`)
- `main` ブランチで本番リリース (e.g. `v1.2.3`)

を行う。
これにより開発フローを `develop` -- PR --> `pre-release` -- PR --> `main` という形に変更。

## fix:

- コンテナイメージに複数タグをつけるときの処理が間違っていたのを修正。